### PR TITLE
Quality updates

### DIFF
--- a/cpp_practice/CMakeLists.txt
+++ b/cpp_practice/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 
 include_directories(${CMAKE_SOURCE_DIR})
 					
-add_executable(practice WIN32 MACOSX_BUNDLE main.cpp vec.h)
+add_executable(practice  MACOSX_BUNDLE main.cpp vec.h)
 
 #Windows cleanup
 if (MSVC)

--- a/cpp_practice/vec.h
+++ b/cpp_practice/vec.h
@@ -33,7 +33,10 @@ struct vec2 {
     //  --- Constructors and Destructors ---
     //
 
-    vec2( float s = float(0.0) ) :
+    vec2(  ) :
+	x(float(0.0)), y(float(0.0)) {}
+
+    explicit vec2( float s ) :
 	x(s), y(s) {}
 
     vec2( float x, float y ) :
@@ -172,7 +175,10 @@ struct vec3 {
     //  --- Constructors and Destructors ---
     //
 
-    vec3( float s = float(0.0) ) :
+    vec3(  ) :
+	x(float(0.0)), y(float(0.0)), z(float(0.0)) {}
+
+    explicit vec3( float s ) :
 	x(s), y(s), z(s) {}
 
     vec3( float x, float y, float z ) :
@@ -322,7 +328,10 @@ struct vec4 {
     //  --- Constructors and Destructors ---
     //
 
-    vec4( float s = float(0.0) ) :
+    vec4(  ) :
+	x(float(0.0)), y(float(0.0)), z(float(0.0)), w(float(0.0)) {}
+
+    explicit vec4( float s ) :
 	x(s), y(s), z(s), w(s) {}
 
     vec4( float x, float y, float z, float w ) :

--- a/hello_opengl/.gitignore
+++ b/hello_opengl/.gitignore
@@ -1,0 +1,1 @@
+/shaders/shader.h

--- a/hello_opengl/CMakeLists.txt
+++ b/hello_opengl/CMakeLists.txt
@@ -29,6 +29,8 @@ add_executable(square WIN32 MACOSX_BUNDLE
 	shaders/vshader.glsl
 	source/common/Angel.h
 	source/common/mat.h
+    source/common/u8names.cpp
+    source/common/u8names.h
     source/common/vec.h)
 
 #Windows cleanup

--- a/hello_opengl/shaders/shader.h
+++ b/hello_opengl/shaders/shader.h
@@ -9,7 +9,7 @@
 
 #include <string>
 
-std::string shader_path = "/Users/bsumma/Teaching/graphics/2020/assignment_0/hello_opengl/shaders/";
+std::string shader_path = "C:/Users/Cody/source/repos/codylico/graphics-module-intro/hello_opengl/shaders/";
 
 
 #endif // __SHADER_H__

--- a/hello_opengl/source/common/Angel.h
+++ b/hello_opengl/source/common/Angel.h
@@ -52,11 +52,21 @@ const GLfloat  RadiansToDegrees = 180.0/M_PI;
 #include "vec.h"
 #include "mat.h"
 //#include "CheckError.h"
+#ifdef _WIN32
+#include "u8names.h"
+#endif //_WIN32
 
 static char*
 readShaderSource(const char* shaderFile)
 {
+#ifdef _WIN32
+  std::wstring wcfn;
+  if (u8names_towc(shaderFile, wcfn) != 0)
+    return NULL;
+  FILE* fp = _wfopen(wcfn.c_str(), L"rb");
+#else
   FILE* fp = fopen(shaderFile, "rb");
+#endif //_WIN32
   
   if ( fp == NULL ) { return NULL; }
   

--- a/hello_opengl/source/common/u8names.cpp
+++ b/hello_opengl/source/common/u8names.cpp
@@ -1,0 +1,66 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+//  --- u8names.cpp ---
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#include "u8names.h"
+#include <errno.h>
+
+static
+unsigned int u8names_bytecount(unsigned char lead_ch) {
+  if (lead_ch < 0xC0) {
+    errno = EILSEQ;
+    return 1;
+  }
+  else if (lead_ch < 0xE0)
+    return 2;
+  else if (lead_ch < 0xF0)
+    return 3;
+  else if (lead_ch < 0xF8)
+    return 4;
+  else {
+    errno = EILSEQ;
+    return 1;
+  }
+}
+
+int u8names_towc(const char* nm, std::wstring& out) {
+  const unsigned char* p;
+  for (p = reinterpret_cast<const unsigned char*>(nm); *p; ++p) {
+    const unsigned char v = *p;
+    if (v < 0x80) {
+      /* Latin-1 compatibility */
+      out.push_back(v);
+    }
+    else if (v < 0xC0) {
+      errno = EILSEQ;
+      return EILSEQ;
+    }
+    else {
+      const unsigned int i_count = u8names_bytecount(v);
+      if (i_count == 1) {
+        return EILSEQ;
+      }
+      /* check extension codes */
+      unsigned int i;
+      unsigned long int qv = v & (31u >> (i_count - 2u));
+      for (i = 1; i < i_count; ++i) {
+        unsigned char const v1 = *(p + i);
+        if (v1 < 0x80 || v1 >= 0xC0) {
+          errno = EILSEQ;
+          return EILSEQ;
+        }
+        else qv = (qv << 6) | (v1 & 63);
+      }
+      if (qv >= 0x10000) {
+        const unsigned long int qv_m1 = qv - 0x10000;
+        out.push_back(static_cast<wchar_t>(0xD800 | ((qv_m1 >> 10) & 1023)));
+        out.push_back(static_cast<wchar_t>(0xDC00 | (qv_m1 & 1023)));
+      }
+      else out.push_back(static_cast<wchar_t>(qv));
+      p += i_count - 1;
+    }
+  }
+  return 0;
+}

--- a/hello_opengl/source/common/u8names.h
+++ b/hello_opengl/source/common/u8names.h
@@ -1,0 +1,21 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+//  --- u8names.h ---
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef hg_SourceCommon_u8names_h_
+#define hg_SourceCommon_u8names_h_
+
+#include <string>
+
+/**
+  Convert a UTF-8 encoded file name to a wchar_t-based filename
+    for use with _wfopen.
+  @param nm file name to convert
+  @param[out] out wchar_t file name written here
+  @return zero on success, nonzero on conversion error
+**/
+int u8names_towc(const char* nm, std::wstring& out);
+
+#endif //hg_SourceCommon_u8names_h_

--- a/hello_opengl/source/common/vec.h
+++ b/hello_opengl/source/common/vec.h
@@ -24,8 +24,11 @@ struct vec2 {
     //
     //  --- Constructors and Destructors ---
     //
+    
+    vec2( ) :
+	x(GLfloat(0.0)), y(GLfloat(0.0)) {}
 
-    vec2( GLfloat s = GLfloat(0.0) ) :
+    explicit vec2( GLfloat s ) :
 	x(s), y(s) {}
 
     vec2( GLfloat x, GLfloat y ) :
@@ -164,7 +167,10 @@ struct vec3 {
     //  --- Constructors and Destructors ---
     //
 
-    vec3( GLfloat s = GLfloat(0.0) ) :
+    vec3() :
+    x(GLfloat(0.0)), y(GLfloat(0.0)), z(GLfloat(0.0)) {}
+
+    explicit vec3( GLfloat s ) :
 	x(s), y(s), z(s) {}
 
     vec3( GLfloat x, GLfloat y, GLfloat z ) :
@@ -314,7 +320,10 @@ struct vec4 {
     //  --- Constructors and Destructors ---
     //
 
-    vec4( GLfloat s = GLfloat(0.0) ) :
+    vec4(  ) :
+	x(GLfloat(0.0)), y(GLfloat(0.0)), z(GLfloat(0.0)), w(GLfloat(0.0)) {}
+
+    explicit vec4( GLfloat s ) :
 	x(s), y(s), z(s), w(s) {}
 
     vec4( GLfloat x, GLfloat y, GLfloat z, GLfloat w ) :


### PR DESCRIPTION
- Remove potential pitfalls when working with `Angel::vecN` classes. (for example, `vec3 v = (1,0,2);` silently doing the wrong thing)
- Add support for Unicode file names on Windows.
- Hide the generated shader.h from version control, since it is specific to each student's development device.
- Remove the WIN32 signifier from a console program, to re-enable the console display.